### PR TITLE
Add makefile build to CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,10 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           submodules: true
+      - name: Build Solidity contracts using makefile
+        working-directory: packages/data-union-solidity
+        run: |
+           make build
       - name: Node ${{ matrix.node_version }} - x64 on ${{ matrix.os }}
         uses: actions/setup-node@v2.1.5
         with:

--- a/packages/data-union-solidity/Makefile
+++ b/packages/data-union-solidity/Makefile
@@ -26,7 +26,7 @@ $(OPENZEPPELIN_REPO_DIR):
 		--config advice.detachedHead=false \
 		--depth 1 \
 		--branch v$(OPENZEPPELIN_VERSION) \
-		git@github.com:OpenZeppelin/openzeppelin-contracts.git $(OPENZEPPELIN_REPO_DIR)
+		https://github.com/OpenZeppelin/openzeppelin-contracts.git $(OPENZEPPELIN_REPO_DIR)
 
 SRC_DIR := contracts
 SRCS := $(wildcard $(SRC_DIR)/*.sol) $(wildcard $(SRC_DIR)/*/*.sol)


### PR DESCRIPTION
Re-add the makefile build to CI (acceptance) tests so that it won't accidentally be broken later.

It was previously removed during #107 because the yaml file in master was broken such that NO tests were run.