### PR TITLE
ETH-171: keep revenues better refreshed for ERC-20 (non-677) tokens

### DIFF
--- a/packages/data-union-solidity/contracts/DataUnionSidechain.sol
+++ b/packages/data-union-solidity/contracts/DataUnionSidechain.sol
@@ -312,6 +312,7 @@ contract DataUnionSidechain is Ownable, IERC20Receiver, IERC677Receiver {
                 emit NewMemberEthSent(newMemberEth);
             }
         }
+        refreshRevenue();
     }
 
     function removeMember(address member, LeaveConditionCode leaveConditionCode) public {
@@ -329,6 +330,8 @@ contract DataUnionSidechain is Ownable, IERC20Receiver, IERC677Receiver {
             address listener = partListeners[i];
             try IPartListener(listener).onPart(member, leaveConditionCode) { } catch { }
         }
+
+        refreshRevenue();
     }
 
     // access checked in removeMember
@@ -368,6 +371,8 @@ contract DataUnionSidechain is Ownable, IERC20Receiver, IERC677Receiver {
         require(token.transferFrom(msg.sender, address(this), amount), "error_transfer");
         uint balanceAfter = token.balanceOf(address(this));
         require((balanceAfter - balanceBefore) >= amount, "error_transfer");
+
+        refreshRevenue();
     }
 
     /**
@@ -383,6 +388,7 @@ contract DataUnionSidechain is Ownable, IERC20Receiver, IERC677Receiver {
         info.withdrawnEarnings = info.withdrawnEarnings + amount;
         _increaseBalance(recipient, amount);
         emit TransferWithinContract(msg.sender, recipient, amount);
+        refreshRevenue();
     }
 
     /**
@@ -418,6 +424,7 @@ contract DataUnionSidechain is Ownable, IERC20Receiver, IERC677Receiver {
         public
         returns (uint256)
     {
+        refreshRevenue();
         return withdraw(member, getWithdrawableEarnings(member), sendToMainnet);
     }
 
@@ -433,6 +440,7 @@ contract DataUnionSidechain is Ownable, IERC20Receiver, IERC677Receiver {
         external
         returns (uint256)
     {
+        refreshRevenue();
         return withdrawTo(to, getWithdrawableEarnings(msg.sender), sendToMainnet);
     }
 
@@ -509,6 +517,7 @@ contract DataUnionSidechain is Ownable, IERC20Receiver, IERC677Receiver {
         returns (uint withdrawn)
     {
         require(signatureIsValid(fromSigner, to, 0, signature), "error_badSignature");
+        refreshRevenue();
         return _withdraw(fromSigner, to, getWithdrawableEarnings(fromSigner), sendToMainnet);
     }
 
@@ -545,6 +554,7 @@ contract DataUnionSidechain is Ownable, IERC20Receiver, IERC677Receiver {
         returns (uint256)
     {
         if (amount == 0) { return 0; }
+        refreshRevenue();
         require(amount <= getWithdrawableEarnings(from), "error_insufficientBalance");
         MemberInfo storage info = memberData[from];
         info.withdrawnEarnings += amount;


### PR DESCRIPTION
now it doesn't need to be called before members can withdraw; withdraw actually calls it. Not sure if this is an anti-feature because now earnings will show different number than withdrawAll will withdraw in case there are "unknown" earnings.