### PR TITLE
Bug fix

### DIFF
--- a/packages/data-union-solidity/contracts/LimitWithdrawModule.sol
+++ b/packages/data-union-solidity/contracts/LimitWithdrawModule.sol
@@ -88,6 +88,7 @@ contract LimitWithdrawModule is DataUnionModule, IWithdrawModule, IJoinListener,
      */
     function onWithdraw(address member, address to, IERC677 token, uint amountWei) override external onlyDataUnion {
         require(amountWei >= minimumWithdrawTokenWei, "error_withdrawAmountBelowMinimum");
+        require(memberJoinTimestamp[member] > 0, "error_memberIsInactive");
         require(block.timestamp >= memberJoinTimestamp[member] + requiredMemberAgeSeconds, "error_memberTooNew");
 
         // if the withdraw period is over, we reset the counters


### PR DESCRIPTION
When a user is inactive memberJoinTimestamp is zero and easily pass this restriction:
require(block.timestamp >= memberJoinTimestamp[member] + requiredMemberAgeSeconds, "error_memberTooNew");
So we need to check if the user is inActive force him/her to active user